### PR TITLE
Handle verbosity and files storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info
+__pycache__/
+*.pyc

--- a/cot_reports/cot_reports.py
+++ b/cot_reports/cot_reports.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 
 # cot_hist - downloads compressed bulk files
 
-def cot_hist(cot_report_type = "legacy_fut", store_txt=True):
+def cot_hist(cot_report_type = "legacy_fut", store_txt=True, verbose=True):
     '''Downloads the compressed COT report historical data of the selected report type
     starting from, depending on the selected report type, 1986, 1995 or 2006 until 2016
     from the cftc.gov webpage as zip file, unzips the downloaded folder and returns
@@ -33,39 +33,39 @@ def cot_hist(cot_report_type = "legacy_fut", store_txt=True):
         if cot_report_type== "legacy_fut": 
            url_end = "deacot1986_2016"
            txt = "FUT86_16.txt"
-           print("Selected: COT Legacy report. Futures only.")
+           if verbose: print("Selected: COT Legacy report. Futures only.")
 
         elif cot_report_type == "legacy_futopt": 
            url_end = "deahistfo_1995_2016"
            txt = "Com95_16.txt"
-           print("Selected: COT Legacy report. Futures and Options.")
+           if verbose: print("Selected: COT Legacy report. Futures and Options.")
 
         elif cot_report_type == "supplemental_futopt": 
            url_end = "dea_cit_txt_2006_2016"
            txt = "CIT06_16.txt"
-           print("Selected: COT Sumpplemental report. Futures and Options.")
+           if verbose: print("Selected: COT Sumpplemental report. Futures and Options.")
      
         elif cot_report_type == "disaggregated_fut": 
            url_end = "fut_disagg_txt_hist_2006_2016"
            txt = "F_Disagg06_16.txt"
-           print("Selected: COT Disaggregated report. Futures only.")
+           if verbose: print("Selected: COT Disaggregated report. Futures only.")
 
         elif cot_report_type == "disaggregated_futopt": 
            url_end = "com_disagg_txt_hist_2006_2016"
            txt = "C_Disagg06_16.txt"
-           print("Selected: COT Disaggregated report. Futures and Options.")
+           if verbose: print("Selected: COT Disaggregated report. Futures and Options.")
 
         elif cot_report_type == "traders_in_financial_futures_fut": 
            url_end = "fin_fut_txt_2006_2016"
            txt = "F_TFF_2006_2016.txt" 
-           print("Selected: COT Traders in Financial Futures report. Futures only.")
+           if verbose: print("Selected: COT Traders in Financial Futures report. Futures only.")
 
         elif cot_report_type == "traders_in_financial_futures_futopt": 
            url_end = "fin_com_txt_2006_2016"
            txt = "C_TFF_2006_2016.txt" 
-           print("Selected: COT Traders in Financial Futures report. Futures and Options.")
+           if verbose: print("Selected: COT Traders in Financial Futures report. Futures and Options.")
     except ValueError:    
-           print("""Input needs to be either:
+           if verbose: print("""Input needs to be either:
                 "legacy_fut", "legacy_futopt", supplemental_futopt",
                 "disaggregated_fut", "disaggregated_futopt", 
                 "traders_in_financial_futures_fut" or
@@ -77,7 +77,7 @@ def cot_hist(cot_report_type = "legacy_fut", store_txt=True):
     z.extractall()
     df = pd.read_csv(txt, low_memory=False)
     if store_txt:
-        print("Stored the extracted file", txt, "in the working directory.")
+        if verbose: print("Stored the extracted file", txt, "in the working directory.")
     else:
         os.remove(txt)
     return df
@@ -87,7 +87,7 @@ def cot_hist(cot_report_type = "legacy_fut", store_txt=True):
 
 # cot_year - downloads single years
 
-def cot_year(year = 2020, cot_report_type = "legacy_fut", store_txt=True):    
+def cot_year(year = 2020, cot_report_type = "legacy_fut", store_txt=True, verbose=True):    
     '''Downloads the selected COT report historical data for a single year
     from the cftc.gov webpage as zip file, unzips the downloaded folder and returns
     the cot data as DataFrame.
@@ -113,7 +113,7 @@ def cot_year(year = 2020, cot_report_type = "legacy_fut", store_txt=True):
         
     Raises:
         ValueError: Raises an exception and returns the argument options.'''    
-    print("Selected:", cot_report_type)
+    if verbose: print("Selected:", cot_report_type)
     try: 
         if cot_report_type== "legacy_fut": 
            rep = "deacot"
@@ -155,9 +155,9 @@ def cot_year(year = 2020, cot_report_type = "legacy_fut", store_txt=True):
     z = zipfile.ZipFile(io.BytesIO(r.content))
     z.extractall()
     df = pd.read_csv(txt, low_memory=False)  
-    print("Downloaded single year data from:", year)
+    if verbose: print("Downloaded single year data from:", year)
     if store_txt:
-        print("Stored the file", txt, "in the working directory.")
+        if verbose: print("Stored the file", txt, "in the working directory.")
     else:
         os.remove(txt)
     return df
@@ -168,7 +168,7 @@ def cot_year(year = 2020, cot_report_type = "legacy_fut", store_txt=True):
 
 # cot_all - downloads complete available data of a chosen COT report type
 
-def cot_all(cot_report_type="legacy_fut", store_txt=True): 
+def cot_all(cot_report_type="legacy_fut", store_txt=True, verbose=True): 
     '''Downloads all historical data for the chosen COT report type (compressed historical bulk
     file and all remaining single year files) from the cftc.gov webpage as zip files, 
     unzips the downloaded folders and returns the cot data files merged as a DataFrame.
@@ -192,9 +192,9 @@ def cot_all(cot_report_type="legacy_fut", store_txt=True):
     Raises:
         ValueError: Raises an exception and returns the argument options.'''  
 
-    df = cot_hist(cot_report_type, store_txt=store_txt)
+    df = cot_hist(cot_report_type, store_txt=store_txt, verbose=verbose)
     for i in range(2017, date.today().year+1):
-        years = pd.DataFrame(cot_year(i, cot_report_type, store_txt=store_txt))
+        years = pd.DataFrame(cot_year(i, cot_report_type, store_txt=store_txt, verbose=verbose))
         df = df.append(years, ignore_index=True) 
     return df
 
@@ -203,7 +203,7 @@ def cot_all(cot_report_type="legacy_fut", store_txt=True):
 
 # cot_all_reports - downloads complete available data for all COT report types
 
-def cot_all_reports(store_txt=True):   
+def cot_all_reports(store_txt=True, verbose=True):   
   '''Downloads all available historical information of all COT reports and returns a dataframe for 
   each of the report types - seven in total. 
   The function iterates through cot_reports.cot_all() for each cot report type. 
@@ -225,9 +225,9 @@ def cot_all_reports(store_txt=True):
   l = ["legacy_fut", "legacy_futopt", "supplemental_futopt", "disaggregated_fut", "disaggregated_futopt", "traders_in_financial_futures_fut", "traders_in_financial_futures_futopt"]
 
   for report in l: 
-    print(report)
+    if verbose: print(report)
     temp = '{}'.format(report)
-    vars()[temp] = cot_all(cot_report_type=report, store_txt=store_txt)
+    vars()[temp] = cot_all(cot_report_type=report, store_txt=store_txt, verbose=verbose)
 
   return  vars()['{}'.format("legacy_fut")],vars()['{}'.format("legacy_futopt")],vars()['{}'.format("supplemental_futopt")],\
   vars()['{}'.format("disaggregated_fut")],vars()['{}'.format("disaggregated_futopt")],vars()['{}'.format("traders_in_financial_futures_fut")],\


### PR DESCRIPTION
Hi @NDelventhal,
thank you very much for this nice package!

It allowed me to reproduce [this plot from Investing.com](https://www.investing.com/economic-calendar/cftc-s-p-500-speculative-positions-1619) with:
```python
df_legacy = cot.cot_year(year = 2022, cot_report_type = 'legacy_fut', store_txt=False)
df_sel = df_legacy[df_legacy['Market and Exchange Names']=='S&P 500 Consolidated - CHICAGO MERCANTILE EXCHANGE'].copy()
df_sel['Non-commercial diff'] = df_sel['Noncommercial Positions-Long (All)'] - df_sel['Noncommercial Positions-Short (All)']
df_sel = df_sel.sort_values(by='As of Date in Form YYYY-MM-DD')
df_sel.plot('As of Date in Form YYYY-MM-DD','Non-commercial diff', kind='bar')
plt.axhline(0)
plt.title("Investing.com's CFTC S&P 500 speculative net positions")
plt.show()
```

I would like to contribute, introducing a few little improvements to handle the verbosity and the storage of `txt` files: I think it is a common use case to be interested only in the parsed `DataFrame` without any other printout.

I hope you will find this PR useful, thanks!

Daniele 